### PR TITLE
Install matplotlib automatically

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/giacomomarchioro/PyEnergyDiagrams",
     packages=setuptools.find_packages(),
+    install_requires=open("requirements.txt", "r").readlines(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Some users don't use anaconda, with this change the library can work with a regular python install as well.